### PR TITLE
[Sueaty] iOS와도 통신할 수 있는 코드 추가 및 분석 코드 함수로 분리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,133 @@
+# Created by https://www.toptal.com/developers/gitignore/api/xcode,macos,swift
+# Edit at https://www.toptal.com/developers/gitignore?templates=xcode,macos,swift
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### Swift ###
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## User settings
+xcuserdata/
+
+## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
+*.xcscmblueprint
+*.xccheckout
+
+## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
+build/
+DerivedData/
+*.moved-aside
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+
+## Obj-C/Swift specific
+*.hmap
+
+## App packaging
+*.ipa
+*.dSYM.zip
+*.dSYM
+
+## Playgrounds
+timeline.xctimeline
+playground.xcworkspace
+
+# Swift Package Manager
+# Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
+# Packages/
+# Package.pins
+# Package.resolved
+# *.xcodeproj
+# Xcode automatically generates this directory with a .xcworkspacedata file and xcuserdata
+# hence it is not needed unless you have added a package configuration file to your project
+# .swiftpm
+
+.build/
+
+# CocoaPods
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+# Pods/
+# Add this line if you want to avoid checking in source code from the Xcode workspace
+# *.xcworkspace
+
+# Carthage
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+# Carthage/Checkouts
+
+Carthage/Build/
+
+# Accio dependency management
+Dependencies/
+.accio/
+
+# fastlane
+# It is recommended to not store the screenshots in the git repo.
+# Instead, use fastlane to re-generate the screenshots whenever they are needed.
+# For more information about the recommended setup visit:
+# https://docs.fastlane.tools/best-practices/source-control/#source-control
+
+fastlane/report.xml
+fastlane/Preview.html
+fastlane/screenshots/**/*.png
+fastlane/test_output
+
+# Code Injection
+# After new code Injection tools there's a generated folder /iOSInjectionProject
+# https://github.com/johnno1962/injectionforxcode
+
+iOSInjectionProject/
+
+### Xcode ###
+# Xcode
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+
+
+
+## Gcc Patch
+/*.gcno
+
+### Xcode Patch ###
+*.xcodeproj/*
+!*.xcodeproj/project.pbxproj
+!*.xcodeproj/xcshareddata/
+!*.xcworkspace/contents.xcworkspacedata
+**/xcshareddata/WorkspaceSettings.xcsettings
+
+# End of https://www.toptal.com/developers/gitignore/api/xcode,macos,swift

--- a/app.py
+++ b/app.py
@@ -5,28 +5,45 @@ import numpy as np
 app = Flask(__name__)
 model = pickle.load(open('.\AdaBoostmodel.pkl', 'rb'))
 
+def getPredictedAttack():
+    # result = request.form : 폼 관련 데이터 다루는 곳
+    if reqeust.method == 'POST':
+        #입력받은 여러개의 데이터들을 [np.array]로 저장해서, predict.
+        test_log = request.form['log']
+        test_log = test_log.split(',')
+        test_log = list(map(float, test_log))
+        preds = model.predict([np.array(test_log)])[0]
+
+        ## mapping 정보
+        attack_cat = ['Analysis', 'Backdoor', 'DoS', 'Exploits', 'Fuzzers', 'Generic', 'Normal', 'Reconnaissance', 'Shellcode', 'Worms']
+        global prediction
+        prediction = attack_cat[preds]
+
+        return prediction
+
 @app.route('/')
 def index():
     return render_template('index.html')
 
 @app.route('/result',methods = ['POST', 'GET'])
 def result():
-    import numpy as np
-    if request.method == 'POST':
-      #result = request.form #폼 관련데이터 다루는 곳
-    
-    # 입력받은 여러개의 데이터들을 [np.array]로 저장해서, predict.
-      test_log = request.form['log']
-      test_log = test_log.split(',')
-      test_log = list(map(float, test_log))
-      preds = model.predict([np.array(test_log)])[0]
+    preds_attack = getPredictedAttack()
+    return render_template("result.html", result = preds_attack)
 
-      ## mapping 정보
-      attack_cat = ['Analysis', 'Backdoor', 'DoS', 'Exploits', 'Fuzzers', 'Generic', 'Normal', 'Reconnaissance', 'Shellcode', 'Worms']
-      preds_attack = attack_cat[preds]
+@app.route('/entry', methods = ['POST'])
+def home():
+    data = request.get_json()
 
-      #return render_template("result.html",result = result)
-    return render_template("result.html",result = preds_attack)
+    numberOfFields = data.get("numberOfFields")
+    result = data.get("result")
+
+    result = prediction
+
+    data = {
+        "numberOfFields" : numberOfFields,
+        "result" : result
+    }
+    return jsonify(data)
 
 @app.route('/info')
 def info():


### PR DESCRIPTION
- iOS와 통신할 수 있는 부분 : @app.route('/entry', methods = ['POST'])
   - 현재 numberOfFields는 무시해도 되는 변수
   - iOS에게 넘어갈 때는 json형태로  encode되어 전달 됨
- 기존에 /result 내에 있던 분석 코드를 함수로 따로 분리함
   - 'prediction'이라는 변수를 전역 변수로 만들어, 웹 부분과 iOS부분이 공통으로 사용할 수 있게끔 분리